### PR TITLE
KVM: x86: Include module.h in vac.c

### DIFF
--- a/arch/x86/kvm/vac.c
+++ b/arch/x86/kvm/vac.c
@@ -1,5 +1,6 @@
 // SPDX-License-Identifier: GPL-2.0
 
+#include <linux/module.h>
 #include "vac.h"
 
 #ifdef CONFIG_HAVE_KVM_VAC


### PR DESCRIPTION
Fixes build.