### PR TITLE
X86/vac/hw operations in vac v3 review

### DIFF
--- a/arch/x86/kvm/svm/svm.c
+++ b/arch/x86/kvm/svm/svm.c
@@ -4921,7 +4921,9 @@ static __init int svm_hardware_setup(void)
 	kvm_caps.max_tsc_scaling_ratio = SVM_TSC_RATIO_MAX;
 	kvm_caps.tsc_scaling_ratio_frac_bits = 32;
 
-	tsc_aux_uret_slot = kvm_add_user_return_msr(MSR_TSC_AUX);
+	tsc_aux_uret_slot = kvm_find_user_return_msr(MSR_TSC_AUX);
+	if (tsc_aux_uret_slot == -1)
+		tsc_aux_uret_slot = kvm_add_user_return_msr(MSR_TSC_AUX);
 
 	if (boot_cpu_has(X86_FEATURE_AUTOIBRS))
 		kvm_enable_efer_bits(EFER_AUTOIBRS);

--- a/arch/x86/kvm/svm/svm.c
+++ b/arch/x86/kvm/svm/svm.c
@@ -4645,6 +4645,7 @@ static int svm_vm_init(struct kvm *kvm)
 void svm_module_exit(void)
 {
 	kvm_exit();
+	kvm_x86_vendor_exit();
 }
 
 static struct kvm_x86_ops svm_x86_ops __initdata = {

--- a/arch/x86/kvm/vac.c
+++ b/arch/x86/kvm/vac.c
@@ -85,6 +85,8 @@ int kvm_add_user_return_msr(u32 msr)
 
 	if (kvm_probe_user_return_msr(msr))
 		return -1;
+	if (kvm_find_user_return_msr(msr) != -1)
+		return -1;
 
 	kvm_uret_msrs_list[kvm_nr_uret_msrs] = msr;
 	return kvm_nr_uret_msrs++;

--- a/arch/x86/kvm/x86.c
+++ b/arch/x86/kvm/x86.c
@@ -9244,14 +9244,6 @@ static int __kvm_x86_vendor_init(struct kvm_x86_init_ops *ops)
 		return -ENOMEM;
 	}
 
-	user_return_msrs = alloc_percpu(struct kvm_user_return_msrs);
-	if (!user_return_msrs) {
-		pr_err("failed to allocate percpu kvm_user_return_msrs\n");
-		r = -ENOMEM;
-		goto out_free_x86_emulator_cache;
-	}
-	kvm_nr_uret_msrs = 0;
-
 	r = kvm_mmu_vendor_module_init();
 	if (r)
 		goto out_free_percpu;
@@ -9325,8 +9317,6 @@ out_unwind_ops:
 out_mmu_exit:
 	kvm_mmu_vendor_module_exit();
 out_free_percpu:
-	free_percpu(user_return_msrs);
-out_free_x86_emulator_cache:
 	kmem_cache_destroy(x86_emulator_cache);
 	return r;
 }
@@ -9364,7 +9354,6 @@ void kvm_x86_vendor_exit(void)
 #endif
 	static_call(kvm_x86_hardware_unsetup)();
 	kvm_mmu_vendor_module_exit();
-	free_percpu(user_return_msrs);
 	kmem_cache_destroy(x86_emulator_cache);
 #ifdef CONFIG_KVM_XEN
 	static_key_deferred_flush(&kvm_xen_enabled);


### PR DESCRIPTION
I think a sane way for us to handle uret MSRs will be to add them to the table only once; and to have only the first kvm's _online calls capture the host value for them. WDYT?

@sean-jc, @asg-17 ?