### PR TITLE
KVM: VMX: Move allocation/deallocation of vmcs area into VAC

### DIFF
--- a/arch/x86/kvm/vmx/vac.h
+++ b/arch/x86/kvm/vmx/vac.h
@@ -3,9 +3,6 @@
 #include "../vac.h"
 #include "vmx_ops.h"
 
-void vac_set_vmxarea(struct vmcs *vmcs, int cpu);
-struct vmcs *vac_get_vmxarea(int cpu);
-
 void vac_crash_vmclear_local_loaded_vmcss(void);
 void vac_add_vmcs_to_loaded_vmcss_on_cpu(
 		struct list_head *loaded_vmcss_on_cpu_link,


### PR DESCRIPTION
Otherwise unloading one module causes active KVMs to see an empty host area (root vmcs).

Fixes: https://github.com/vsrinivas/linux/issues/8