### PR TITLE
KVM: VAC: VMX: Move allocation of vmxon area into init

### DIFF
--- a/.github/workflows/c-cpp.yml
+++ b/.github/workflows/c-cpp.yml
@@ -1,0 +1,27 @@
+name: C/C++ CI
+
+on:
+  push:
+    branches: [ "x86/vac/hw-operations-in-vac-v3" ]
+  pull_request:
+    branches: [ "x86/vac/hw-operations-in-vac-v3" ]
+
+jobs:
+  build:
+
+    runs-on: self-hosted
+
+    steps:
+    - uses: actions/checkout@v3
+    - name: make mrproper (minimal)
+      run: make mrproper
+    - name: config (minimal)
+      run: wget https://gist.githubusercontent.com/vsrinivas/125460123140af2c2c1f0e0fd4cab874/raw/e0868389b5660ea869d7fad837014f0bb2d20cb3/gistfile1.txt -O .config
+    - name: make (minimal)
+      run: make CC="ccache cc" -j`nproc` && make CC="ccache cc" M=arch/x86/kvm modules
+    - name: fetch testdisk (minimal)
+      run: wget https://github.com/vsrinivas/xtest/raw/master/testdisk.img.gz -O testdisk.img.gz
+    - name: unpack testdisk (minimal)
+      run: gunzip testdisk.img.gz
+    - name: test boot (minimal)
+      run: qemu-system-x86_64 --enable-kvm -kernel vmlinux -append "console=ttyS0 root=/dev/nvme0n1 init=/sbin/sh" -smp 1 -m 1G  -display none -serial stdio -drive file=testdisk.img,if=none,id=nvme -device nvme,drive=nvme,serial=disk -no-reboot

--- a/arch/x86/kvm/svm/vac.c
+++ b/arch/x86/kvm/svm/vac.c
@@ -178,3 +178,7 @@ int __init vac_svm_init(void)
 {
 	return 0;
 }
+
+void vac_svm_exit(void)
+{
+}

--- a/arch/x86/kvm/vac.c
+++ b/arch/x86/kvm/vac.c
@@ -180,8 +180,15 @@ int __init vac_init(void)
 }
 module_init(vac_init);
 
+extern void vac_vmx_exit(void);
+extern void vac_svm_exit(void);
 void __exit vac_exit(void)
 {
+	if (cpu_has_vmx()) {
+		vac_vmx_exit();
+	} else if (cpu_has_svm(NULL)) {
+		vac_svm_exit();
+	}
 	free_percpu(user_return_msrs);
 }
 module_exit(vac_exit);

--- a/arch/x86/kvm/vmx/vac.c
+++ b/arch/x86/kvm/vmx/vac.c
@@ -196,7 +196,7 @@ int vmx_hardware_enable(void)
 
 	intel_pt_handle_vmx(1);
 
-	phys_addr = __pa(this_cpu_ptr(vmxon_vmcs));
+	phys_addr = __pa(per_cpu(vmxon_vmcs, cpu));
 	r = kvm_cpu_vmxon(phys_addr);
 	if (r) {
 		intel_pt_handle_vmx(0);


### PR DESCRIPTION
Removes requirement for GFP_ATOMIC mallocation.

Suggested-by: Sean <seanjc@google.com>